### PR TITLE
Update rabbit.tf

### DIFF
--- a/example-1/scripts/rabbit.tf
+++ b/example-1/scripts/rabbit.tf
@@ -26,7 +26,7 @@ resource "kubernetes_deployment" "rabbit" {
 
       spec {
         container {
-          image = "rabbitmq:3-management"
+          image = "rabbitmq:3.8.1-management"
           name  = "rabbit"
 
           port {


### PR DESCRIPTION
Fix a typo error in rabbit.tf, the rabbitmq version was incomplete (3 vs 3.8.1). The code in the book is correct.